### PR TITLE
Обновил пути для интелесенс

### DIFF
--- a/Getting_started/.vscode/c_cpp_properties.json
+++ b/Getting_started/.vscode/c_cpp_properties.json
@@ -7,7 +7,8 @@
             ],
             "includePath": [
                 "${workspaceFolder}/**",
-                "C:/Users/Vasiliy/src/arm/mbed/mbed-os/**"
+                "C:/Users/Vasiliy/src/arm/mbed/mbed-os/**",
+				"C:/Users/Vasiliy/src/arm/mbed/mbed-os/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/"
             ],
             "defines": [
                 "_DEBUG",


### PR DESCRIPTION
Чтобы vscode видел предефайны для установленого на плате оборудования (кнопки, светодиоды и т.д.) нужно ещё указать в путях  конкретно нашу плату. Т.к. если рекурсивно включать, то там много таких же предефайнов, он путается и не находит нужные в одном файле.